### PR TITLE
Multiple aggregates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion      := "0.1"
+ThisBuild / tlBaseVersion      := "0.2"
 ThisBuild / crossScalaVersions := Seq("2.13.13", "3.4.0")
 
 ThisBuild / tlCiReleaseBranches += "main"

--- a/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/ghost/GhostClient.scala
@@ -27,10 +27,10 @@ object GhostClient {
     url: String
   ): Resource[F, GhostClient[F]] = {
     val ghostStatus: Resource[F, Giapi[F]] =
-      Resource.make(Giapi.giapiConnection[F](url).connect)(_.close)
+      Resource.make(Giapi.giapiConnection[F](url, Nil).connect)(_.close)
 
     val ghostSequence: Resource[F, Giapi[F]] =
-      Resource.make(Giapi.giapiConnection[F](url).connect)(_.close)
+      Resource.make(Giapi.giapiConnection[F](url, Nil).connect)(_.close)
 
     for {
       _ <- ghostStatus

--- a/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
+++ b/modules/giapi/src/main/scala/giapi/client/gpi/GpiClient.scala
@@ -162,13 +162,13 @@ object GpiClient {
   ): Resource[F, GpiClient[F]] = {
     val giapi: Resource[F, Giapi[F]] =
       Resource.make(
-        Giapi.giapiConnection[F](url).connect
+        Giapi.giapiConnection[F](url, Nil).connect
       )(_.close)
 
     val db: Resource[F, GiapiStatusDb[F]] =
       Resource.make(
         GiapiStatusDb
-          .newStatusDb[F](url, statusesToMonitor)
+          .newStatusDb[F](url, statusesToMonitor, Nil)
       )(_.close)
 
     (giapi, db).mapN(new GpiClientImpl[F](_, _)).widen[GpiClient[F]]

--- a/modules/giapi/src/test/scala/giapi/client/GiapiCommandSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiCommandSpec.scala
@@ -80,7 +80,7 @@ final class GiapiCommandSpec extends CatsEffectSuite {
       _ <- Resource.make(GmpCommands.createGmpCommands(amqUrl, handleCommands))(
              GmpCommands.closeGmpCommands
            )
-      c <- Resource.make(Giapi.giapiConnection[IO](amqUrl).connect)(_.close)
+      c <- Resource.make(Giapi.giapiConnection[IO](amqUrl, Nil).connect)(_.close)
     } yield c
 
   test("Test sending a command with no handlers".ignore) { // This test passes but the backend doesn't clean up properly

--- a/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiStatusSpec.scala
@@ -83,7 +83,7 @@ final class GiapiStatusSpec extends CatsEffectSuite {
       g <- Resource.make(GmpStatus.createGmpStatus(amqUrl, intItemName, strItemName))(
              GmpStatus.closeGmpStatus
            )
-      c <- Resource.make(Giapi.giapiConnection[IO](amqUrl).connect)(_.close)
+      c <- Resource.make(Giapi.giapiConnection[IO](amqUrl, Nil).connect)(_.close)
     } yield (g, c)
 
   test("Test reading an existing status item") {


### PR DESCRIPTION
It was noted that having a single status aggregator is inefficient as we get more data than needed. This new design allows us to partition the status name space to only get a subset, especially when using wildcards:

https://activemq.apache.org/wildcards