### PR TITLE
Always use US locale for number conversion.

### DIFF
--- a/modules/giapi/src/main/scala/giapi/client/GiapiConfig.scala
+++ b/modules/giapi/src/main/scala/giapi/client/GiapiConfig.scala
@@ -3,6 +3,8 @@
 
 package giapi.client
 
+import java.util.Locale
+
 // Produce a configuration string for Giapi.
 trait GiapiConfig[T] {
   def configValue(t: T): String
@@ -11,8 +13,8 @@ trait GiapiConfig[T] {
 object GiapiConfig {
   implicit val stringConfig: GiapiConfig[String] = t => t
   implicit val intConfig: GiapiConfig[Int]       = _.toString
-  implicit val doubleConfig: GiapiConfig[Double] = d => f"$d%1.6f"
-  implicit val floatConfig: GiapiConfig[Float]   = d => f"$d%1.6f"
+  implicit val doubleConfig: GiapiConfig[Double] = d => "%1.6f".formatLocal(Locale.US, d)
+  implicit val floatConfig: GiapiConfig[Float]   = d => "%1.6f".formatLocal(Locale.US, d)
 
   @inline
   def apply[A](implicit instance: GiapiConfig[A]): GiapiConfig[A] = instance

--- a/modules/giapi/src/test/scala/giapi/client/GiapiConfigSpec.scala
+++ b/modules/giapi/src/test/scala/giapi/client/GiapiConfigSpec.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package giapi.client
+
+import munit.CatsEffectSuite
+
+import java.util.Locale
+
+import GiapiConfig.given
+
+final class GiapiConfigSpec extends CatsEffectSuite {
+
+  test("GiapiConfig basic types") {
+    Locale.setDefault(Locale.GERMANY)
+    assertEquals(GiapiConfig[String].configValue("dummy"), "dummy")
+    assertEquals(GiapiConfig[Int].configValue(1234), "1234")
+    assertEquals(GiapiConfig[Double].configValue(3.1415), "3.141500")
+    assertEquals(GiapiConfig[Double].configValue(3.1415f), "3.141500")
+  }
+
+}


### PR DESCRIPTION
Floating and Double conversion was depending on the host machine default locale. I set it to always use US locale.